### PR TITLE
Avoid precision loss for float variable

### DIFF
--- a/compressor/src/main/java/id/zelory/compressor/ImageUtil.java
+++ b/compressor/src/main/java/id/zelory/compressor/ImageUtil.java
@@ -42,7 +42,7 @@ class ImageUtil {
         int actualHeight = options.outHeight;
         int actualWidth = options.outWidth;
 
-        float imgRatio = actualWidth / actualHeight;
+        float imgRatio = (float)actualWidth / actualHeight;
         float maxRatio = maxWidth / maxHeight;
 
         //width and height values are set maintaining the aspect ratio of the image


### PR DESCRIPTION
Forced a floating-point division by casting the dividend to avoid the loss of precision for the `imgRatio`. Previously, it was doing an integral division which truncates the result to the closest integer to zero and then it was casting the result to float.