### PR TITLE
Create friendly api to Compressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,35 @@ GlobalScope.launch {
 val compressedImageFile = Compressor.compress(context, actualImageFile, Dispatchers.Main)
 ```
 
+### Compressor with a friendly api using ImageCompressor  
+```kotlin  
+ImageCompressor.with(context)  
+ .launchOn(Dispatchers.IO) // set a CoroutineContext (Optional, default = Dispatchers.IO)
+ .observeOn(lifecycleScope) // set a CoroutineScope
+ .applyCompressionWith { // options 
+    resolution(1280, 720) 
+    format(Bitmap.CompressFormat.WEBP) 
+    ... 
+ }.compress(inputImg) { outputImage -> 
+    // get output image here 
+ }
+```  
+Logging exceptions too:  
+```kotlin  
+ImageCompressor.with(context)  
+ .launchOn(coroutineContext)
+ .observeOn(coroutineScope)  
+ .applyCompressionWith { ... }
+ .compress(inputImg,        
+    onFailure = { throwable ->  
+        // log exception here 
+    }, 
+    onSuccess = { outputImage -> 
+        // get output image here 
+    } 
+)
+```
+
 ### Old version
 Please read this [readme](https://github.com/zetbaitsu/Compressor/blob/master/README_v2.md)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    //implementation project(':compressor')
-    implementation 'id.zelory:compressor:3.0.0'
+    implementation project(':compressor')
+    //implementation 'id.zelory:compressor:3.0.0'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/compressor/src/main/java/id/zelory/compressor/ImageCompressor.kt
+++ b/compressor/src/main/java/id/zelory/compressor/ImageCompressor.kt
@@ -1,0 +1,103 @@
+package id.zelory.compressor
+
+import android.content.Context
+import id.zelory.compressor.constraint.Compression
+import id.zelory.compressor.constraint.default
+import id.zelory.compressor.constraint.destination
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Created on : April 12, 2020
+ * @author     : jeziellago
+ * Name       : Jeziel Lago
+ * GitHub     : https://github.com/jeziellago
+ */
+class ImageCompressor private constructor(private val context: Context) {
+
+    private var compressionPatch: Compression.() -> Unit = { default() }
+    private var coroutineContext: CoroutineContext = Dispatchers.IO
+    private var coroutineScope: CoroutineScope? = null
+    private var outputImageFile: File? = null
+
+    /***
+     * @param patch is a block of configuration using [Compression] types.
+     * e.g.
+     * ImageCompressor.with(context)
+     *     .applyCompressionWith{
+     *         resolution(1280, 720)
+     *         quality(80)
+     *         format(Bitmap.CompressFormat.WEBP)
+     *         ...
+     *     }
+     */
+    fun applyCompressionWith(patch: Compression.() -> Unit) = apply { compressionPatch = patch }
+
+    /***
+     * @param coroutineCtx [CoroutineContext] where compressor will run.
+     * Default: Dispatchers.IO
+     * @see [Dispatchers]
+     */
+    fun launchOn(coroutineCtx: CoroutineContext) = apply { coroutineContext = coroutineCtx }
+
+    /***
+     * @param scope [CoroutineScope] required to launch the compression task.
+     * e.g: lifecycleScope, viewModelScope, customCoroutineScope, etc.
+     */
+    fun observeOn(scope: CoroutineScope) = apply { coroutineScope = scope }
+
+    /***
+     * @param output [File] expected to save compressed image.
+     * It is an optional param.
+     */
+    fun saveOn(output: File) = apply {
+        outputImageFile = output
+    }
+
+    /***
+     * @param inputImageFile [File]
+     * @param onFailure, (optional param), receive a [Throwable] on failure cases.
+     * @param onSuccess, block to receive output compressed image file.
+     *
+     * @throws [IllegalArgumentException] if `coroutineScope` is not received from `observeOn` method.
+     *
+     * @see [Compressor]
+     */
+    fun compress(
+            inputImageFile: File,
+            onFailure: ((Throwable) -> Unit)? = null,
+            onSuccess: (outputImage: File) -> Unit
+    ) {
+        coroutineScope?.launch {
+            try {
+                val compressionOptions = outputImageFile?.let {
+                    fun Compression.() {
+                        destination(it)
+                        compressionPatch.invoke(this)
+                    }
+                } ?: compressionPatch
+
+                val result = Compressor.compress(
+                        context,
+                        inputImageFile,
+                        coroutineContext,
+                        compressionOptions
+                )
+                onSuccess(result)
+            } catch (e: Throwable) {
+                onFailure?.invoke(e)
+            }
+        } ?: throw IllegalArgumentException("CoroutineScope is required.\nSee `observeOn` method.")
+    }
+
+    companion object Creator {
+        /***
+         * @param context [Context], required to create ImageCompressor
+         * @return [ImageCompressor]
+         */
+        fun with(context: Context) = ImageCompressor(context)
+    }
+}

--- a/compressor/src/test/java/id/zelory/compressor/ImageCompressorTest.kt
+++ b/compressor/src/test/java/id/zelory/compressor/ImageCompressorTest.kt
@@ -1,0 +1,131 @@
+package id.zelory.compressor
+
+import android.graphics.Bitmap
+import id.zelory.compressor.constraint.DefaultConstraint
+import id.zelory.compressor.constraint.FormatConstraint
+import id.zelory.compressor.constraint.QualityConstraint
+import id.zelory.compressor.constraint.ResolutionConstraint
+import id.zelory.compressor.constraint.format
+import id.zelory.compressor.constraint.quality
+import id.zelory.compressor.constraint.resolution
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ImageCompressorTest {
+
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("id.zelory.compressor.UtilKt")
+        every { copyToCache(any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `compress with default specs should execute default constraint`() = testDispatcher.runBlockingTest {
+        // Given
+        mockkConstructor(DefaultConstraint::class)
+        var executedConstraint = 0
+        every { anyConstructed<DefaultConstraint>().isSatisfied(any()) } answers {
+            executedConstraint > 0
+        }
+        every { anyConstructed<DefaultConstraint>().satisfy(any()) } answers {
+            executedConstraint++
+            mockk(relaxed = true)
+        }
+
+        // When
+        ImageCompressor.with(mockk(relaxed = true))
+                .launchOn(testDispatcher)
+                .observeOn(this)
+                .compress(mockk(relaxed = true), {}, {})
+
+        // Then
+        verify {
+            anyConstructed<DefaultConstraint>().isSatisfied(any())
+            anyConstructed<DefaultConstraint>().satisfy(any())
+        }
+    }
+
+    @Test
+    fun `compress with custom specs should execute all constraint provided`() = testDispatcher.runBlockingTest {
+        // Given
+        mockkConstructor(ResolutionConstraint::class)
+        mockkConstructor(QualityConstraint::class)
+        mockkConstructor(FormatConstraint::class)
+
+        var executedConstraint = 0
+        every { anyConstructed<ResolutionConstraint>().isSatisfied(any()) } answers {
+            executedConstraint > 0
+        }
+        every { anyConstructed<ResolutionConstraint>().satisfy(any()) } answers {
+            executedConstraint++
+            mockk(relaxed = true)
+        }
+
+        every { anyConstructed<QualityConstraint>().isSatisfied(any()) } answers {
+            executedConstraint > 1
+        }
+        every { anyConstructed<QualityConstraint>().satisfy(any()) } answers {
+            executedConstraint++
+            mockk(relaxed = true)
+        }
+
+        every { anyConstructed<FormatConstraint>().isSatisfied(any()) } answers {
+            executedConstraint > 2
+        }
+        every { anyConstructed<FormatConstraint>().satisfy(any()) } answers {
+            executedConstraint++
+            mockk(relaxed = true)
+        }
+
+        // When
+        ImageCompressor.with(mockk(relaxed = true))
+                .launchOn(testDispatcher)
+                .observeOn(this)
+                .applyCompressionWith {
+                    resolution(100, 100)
+                    quality(75)
+                    format(Bitmap.CompressFormat.PNG)
+                }.saveOn(mockk(relaxed = true))
+                .compress(mockk(relaxed = true), {}, {})
+
+        // Then
+        verify {
+            anyConstructed<ResolutionConstraint>().isSatisfied(any())
+            anyConstructed<ResolutionConstraint>().satisfy(any())
+            anyConstructed<QualityConstraint>().isSatisfied(any())
+            anyConstructed<QualityConstraint>().satisfy(any())
+            anyConstructed<FormatConstraint>().isSatisfied(any())
+            anyConstructed<FormatConstraint>().satisfy(any())
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `compress with missed coroutineScope should throw IllegalArgumentException`() = testDispatcher.runBlockingTest {
+        // Then
+        ImageCompressor.with(mockk(relaxed = true))
+                .launchOn(testDispatcher)
+                .compress(mockk(relaxed = true), {}, {})
+    }
+
+    @After
+    fun cleanUp() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+}


### PR DESCRIPTION
Create friendly "API" to compressor:
```kotlin  
ImageCompressor.with(context)  
 .launchOn(Dispatchers.IO) // set a CoroutineContext (Optional, default = Dispatchers.IO)
 .observeOn(lifecycleScope) // set a CoroutineScope
 .applyCompressionWith { // options 
    resolution(1280, 720) 
    format(Bitmap.CompressFormat.WEBP) 
    ... 
 }.compress(inputImg) { outputImage -> 
    // get output image here 
 }
```

With that implementation is possible to use any DI framework to provide an `ImageCompressor` instance, enabling more reusability and decoupling of android `Context`.

See implementation here [ImageCompressor.kt](https://github.com/jeziellago/Compressor/blob/create-image-compressor/compressor/src/main/java/id/zelory/compressor/ImageCompressor.kt)