### PR TITLE
Fixed crash being caused by `The source file doesn't exist`

### DIFF
--- a/compressor/src/main/java/id/zelory/compressor/constraint/DestinationConstraint.kt
+++ b/compressor/src/main/java/id/zelory/compressor/constraint/DestinationConstraint.kt
@@ -14,6 +14,9 @@ class DestinationConstraint(private val destination: File) : Constraint {
     }
 
     override fun satisfy(imageFile: File): File {
+        if (!destination.exists()) {
+            destination.createNewFile()
+        }
         return imageFile.copyTo(destination, true)
     }
 }


### PR DESCRIPTION
Fixed crash being caused by `The source file doesn't exist` when calling `DestinationConstraint.satisfy(File)`