### PR TITLE
More precise image resolution

### DIFF
--- a/compressor/src/main/java/id/zelory/compressor/Util.kt
+++ b/compressor/src/main/java/id/zelory/compressor/Util.kt
@@ -38,10 +38,14 @@ fun decodeSampledBitmapFromFile(imageFile: File, reqWidth: Int, reqHeight: Int):
     return BitmapFactory.Options().run {
         inJustDecodeBounds = true
         BitmapFactory.decodeFile(imageFile.absolutePath, this)
-
         inSampleSize = calculateInSampleSize(this, reqWidth, reqHeight)
-
         inJustDecodeBounds = false
+        val expectSize = outWidth.coerceAtMost(outHeight)
+        val minReqSize = reqWidth.coerceAtMost(reqHeight)
+        if (expectSize > minReqSize) {
+            inDensity = expectSize
+            inTargetDensity = minReqSize * inSampleSize
+        }
         BitmapFactory.decodeFile(imageFile.absolutePath, this)
     }
 }

--- a/compressor/src/main/java/id/zelory/compressor/Util.kt
+++ b/compressor/src/main/java/id/zelory/compressor/Util.kt
@@ -40,11 +40,14 @@ fun decodeSampledBitmapFromFile(imageFile: File, reqWidth: Int, reqHeight: Int):
         BitmapFactory.decodeFile(imageFile.absolutePath, this)
         inSampleSize = calculateInSampleSize(this, reqWidth, reqHeight)
         inJustDecodeBounds = false
-        val expectSize = outWidth.coerceAtMost(outHeight)
-        val minReqSize = reqWidth.coerceAtMost(reqHeight)
-        if (expectSize > minReqSize) {
-            inDensity = expectSize
-            inTargetDensity = minReqSize * inSampleSize
+        val outRatio = outWidth.toFloat() / outHeight.toFloat()
+        val reqRatio = reqWidth.toFloat() / reqHeight.toFloat()
+        if (outRatio > reqRatio) {
+            inDensity = outHeight
+            inTargetDensity = reqHeight * inSampleSize
+        } else if (outRatio <= reqRatio) {
+            inDensity = outWidth
+            inTargetDensity = reqWidth * inSampleSize
         }
         BitmapFactory.decodeFile(imageFile.absolutePath, this)
     }

--- a/compressor/src/main/java/id/zelory/compressor/constraint/ResolutionConstraint.kt
+++ b/compressor/src/main/java/id/zelory/compressor/constraint/ResolutionConstraint.kt
@@ -19,7 +19,7 @@ class ResolutionConstraint(private val width: Int, private val height: Int) : Co
         return BitmapFactory.Options().run {
             inJustDecodeBounds = true
             BitmapFactory.decodeFile(imageFile.absolutePath, this)
-            outWidth.coerceAtMost(outHeight) <= width.coerceAtMost(height)
+            outWidth - width <= 0 || outHeight - height <= 0
         }
     }
 

--- a/compressor/src/main/java/id/zelory/compressor/constraint/ResolutionConstraint.kt
+++ b/compressor/src/main/java/id/zelory/compressor/constraint/ResolutionConstraint.kt
@@ -19,7 +19,7 @@ class ResolutionConstraint(private val width: Int, private val height: Int) : Co
         return BitmapFactory.Options().run {
             inJustDecodeBounds = true
             BitmapFactory.decodeFile(imageFile.absolutePath, this)
-            calculateInSampleSize(this, width, height) <= 1
+            outWidth.coerceAtMost(outHeight) <= width.coerceAtMost(height)
         }
     }
 


### PR DESCRIPTION
Currently, image resize  depends on the result of sample size. There's a lot of gap between each sample size value.

For example, resize 3,719 x 2,787 px of original image resolution.
```
Target Resolution (px)    Result Resolution (px)
------------------------------------------------
400 x 400                 930 x 697
800 x 800                 1,860 x 1,394
1,200 x 1,200             1,860 x 1,394
1,600 x 1,600             3,719 x 2,787
2,000 x 2,000             3,719 x 2,787
2,400 x 2,400             3,719 x 2,787
2,800 x 2,800             3,719 x 2,787
3,200 x 3,200             3,719 x 2,787
```

You will see a lot of gap for 1,400 x 1,400 px of target resolution because the result of sample size calculation is 1. So it wasn't resized.

For more precise image resize, we have combine the calculation between, `inSampleSize`, `inDensity` and `inTargetDensity` together, not only `inSampleSize`.

These are results from new calculation
```
Target Resolution (px)    Result Resolution (px)
------------------------------------------------
400 x 400                 534 x 400
800 x 800                 1,068 x 800
1,200 x 1,200             1,602 x 1,200
1,600 x 1,600             2,135 x 1,600
2,000 x 2,000             2,669 x 2,000
2,400 x 2,400             3,203 x 2,400
2,800 x 2,800             3,719 x 2,787
3,200 x 3,200             3,719 x 2,787
```

But there is trade-off between current resize calculation compare to my pull request. It is about the execution time. 

```
Target Resolution (px)        Before (ms)        After (ms)         Diff
------------------------------------------------------------------------
400 x 400                     111                71                 -36.03%
800 x 800                     237                134                -43.45%
1,200 x 1,200                 231                218                -5.62%
1,600 x 1,600                 288                363                +26.04%
2,000 x 2,000                 288                500                +73.61%
2,400 x 2,400                 297                644                +116.83%
2,800 x 2,800                 289                288                ~0%
3,200 x 3,200                 289                289                ~0%
```

If you focus on execution time more than precise resolution, feel free to ignore this pull request or tell me to create it as new constraint.

